### PR TITLE
Bump Vapor dependency to 1.4.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "VaporApp",
     dependencies: [
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 3)
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 4)
     ],
     exclude: [
         "Config",


### PR DESCRIPTION
This is a trivial/chore-level change to help new and seasoned users alike to quickly start with the new framework version.