### PR TITLE
Don't exclude Tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,5 @@ let package = Package(
         "Localization",
         "Public",
         "Resources",
-        "Tests",
     ]
 )


### PR DESCRIPTION
SPM creates an empty Tests folder, so there's no harm in keeping it included into the .xcodeproj file generated by SPM. On the contrary, it prevents hours of debugging trying to figure out why test files aren't shown inside Xcode when one decides to add some Unit Tests to the project created with this template.