### PR TITLE
Make whitespace consistent in template source files

### DIFF
--- a/Config/app.json
+++ b/Config/app.json
@@ -1,3 +1,3 @@
 {
-	"foo": "foo-bar"
+    "foo": "foo-bar"
 }

--- a/Config/droplet.json
+++ b/Config/droplet.json
@@ -15,7 +15,7 @@
             "sessions"
         ],
         "client": [
-        
+
         ]
     }
 }

--- a/Config/production/app.json
+++ b/Config/production/app.json
@@ -1,3 +1,3 @@
 {
-	"key": "$VAPOR_APP_KEY"
+    "key": "$VAPOR_APP_KEY"
 }

--- a/Config/servers.json
+++ b/Config/servers.json
@@ -1,7 +1,7 @@
 {
-	"default": {
-		"port": "$PORT:8080",
-		"host": "0.0.0.0",
-		"securityLayer": "none"
-	}
+    "default": {
+        "port": "$PORT:8080",
+        "host": "0.0.0.0",
+        "securityLayer": "none"
+    }
 }

--- a/Localization/en-US.json
+++ b/Localization/en-US.json
@@ -1,5 +1,5 @@
 {
     "welcome": {
-    	"title": "It works."
+        "title": "It works."
     }
 }

--- a/Localization/es-US.json
+++ b/Localization/es-US.json
@@ -1,5 +1,5 @@
 {
     "welcome": {
-    	"title": "Funciona."
+        "title": "Funciona."
     }
 }

--- a/Localization/nl-BE.json
+++ b/Localization/nl-BE.json
@@ -1,5 +1,5 @@
 {
     "welcome": {
-    	"title": "Het werkt."
+        "title": "Het werkt."
     }
 }

--- a/Localization/nl-NL.json
+++ b/Localization/nl-NL.json
@@ -1,5 +1,5 @@
 {
     "welcome": {
-    	"title": "Het werkt."
+        "title": "Het werkt."
     }
 }

--- a/Public/styles/app.css
+++ b/Public/styles/app.css
@@ -1,17 +1,17 @@
 * {
-	box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 body, html {
-	padding: 0;
-	margin: 0;
-	height: 100%;
+    padding: 0;
+    margin: 0;
+    height: 100%;
 }
 
 body {
-	font-family: sans-serif;
-	color: #333;
-	position: relative;
+    font-family: sans-serif;
+    color: #333;
+    position: relative;
 }
 
 #droplet {
@@ -22,13 +22,13 @@ body {
 }
 
 .message {
-	position: absolute;
-	width: 256px;
+    position: absolute;
+    width: 256px;
     height: 64px;
-	text-align: center;
-	top: 50%;
-	left: 50%;
-	margin-left: -128px;
+    text-align: center;
+    top: 50%;
+    left: 50%;
+    margin-left: -128px;
     margin-top: -32px;
     line-height: 0;
 }

--- a/Resources/Views/welcome.leaf
+++ b/Resources/Views/welcome.leaf
@@ -1,10 +1,10 @@
 #extend("base")
 
 #export("head") {
-	<title>My App</title>
+    <title>My App</title>
 
     <link href="https://fonts.googleapis.com/css?family=Quicksand:400,700,300" rel="stylesheet">
-	<link rel="stylesheet" href="/styles/app.css">
+    <link rel="stylesheet" href="/styles/app.css">
 }
 
 #export("body") {

--- a/Sources/App/Models/Post.swift
+++ b/Sources/App/Models/Post.swift
@@ -5,7 +5,7 @@ import Foundation
 final class Post: Model {
     var id: Node?
     var content: String
-    
+
     init(content: String) {
         self.id = UUID().uuidString.makeNode()
         self.content = content

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -4,7 +4,7 @@ let drop = Droplet()
 
 drop.get { req in
     return try drop.view.make("welcome", [
-    	"message": drop.localization[req.lang, "welcome", "title"]
+        "message": drop.localization[req.lang, "welcome", "title"]
     ])
 }
 


### PR DESCRIPTION
I just started my first vapor project using the basic template, and I'm excited~ However, I noticed a few inconsistencies on indentations between files in the repo. To fix it, I just did a simple run of [tabfix](https://github.com/mar10/tabfix).

I don't know what the vapor maintainers' stances are on indent styles, and I'm certainly not here to start a fight! I went with 4-space based on the fact that the majority of the template is already using it. Nobody likes inconsistent indentations.