### PR TITLE
Update Config+Setup.swift

### DIFF
--- a/Sources/App/Config+Setup.swift
+++ b/Sources/App/Config+Setup.swift
@@ -20,6 +20,6 @@ extension Config {
     private func setupPreparations() throws {
         preparations += [
             Post.self
-        ]
+        ] as [Preparation.Type]
     }
 }


### PR DESCRIPTION
As soon as you add multiple preparation types, the type or the array fails to be inferred. This should be safe cast to get around this.