### PR TITLE
consistent confusion resulting from droplet not available in routebui…

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -107,13 +107,13 @@
       "package": "TLS",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/tls.git",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     {
       "package": "Vapor",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/vapor.git",
-      "version": "2.0.2"
+      "version": "2.0.3"
     }
   ],
   "version": 1

--- a/Sources/App/Droplet+Setup.swift
+++ b/Sources/App/Droplet+Setup.swift
@@ -2,6 +2,7 @@
 
 extension Droplet {
     public func setup() throws {
-        try collection(Routes.self)
+        try setupRoutes()
+        // Do any additional droplet setup
     }
 }

--- a/Sources/App/Routes.swift
+++ b/Sources/App/Routes.swift
@@ -1,31 +1,25 @@
 import Vapor
 
-final class Routes: RouteCollection {
-    func build(_ builder: RouteBuilder) throws {
-        builder.get("hello") { req in
+extension Droplet {
+    func setupRoutes() throws {
+        get("hello") { req in
             var json = JSON()
             try json.set("hello", "world")
             return json
         }
 
-        builder.get("plaintext") { req in
+        get("plaintext") { req in
             return "Hello, world!"
         }
-        
+
         // response to requests to /info domain
         // with a description of the request
-        builder.get("info") { req in
+        get("info") { req in
             return req.description
         }
 
-       builder.get("description") { req in return req.description }
+        get("description") { req in return req.description }
         
-        try builder.resource("posts", PostController.self)
+        try resource("posts", PostController.self)
     }
 }
-
-/// Since Routes doesn't depend on anything
-/// to be initialized, we can conform it to EmptyInitializable
-///
-/// This will allow it to be passed by type.
-extension Routes: EmptyInitializable { }


### PR DESCRIPTION
We've been getting constant comments in slack and elsewhere about a lot of confusion about RouteBuilder, how it works, and why it's there. Mostly related to missing droplet, inability to access droplet, and otherwise general confusion. Since it's purely additive organizational and seems to be contrary to most users' expectations, we're keeping the API template more simple.