### PR TITLE
Unified the name of Request parameters across the file

### DIFF
--- a/Sources/App/Controllers/PostController.swift
+++ b/Sources/App/Controllers/PostController.swift
@@ -6,13 +6,13 @@ import HTTP
 final class PostController: ResourceRepresentable {
     /// When users call 'GET' on '/posts'
     /// it should return an index of all available posts
-    func index(req: Request) throws -> ResponseRepresentable {
+    func index(_ req: Request) throws -> ResponseRepresentable {
         return try Post.all().makeJSON()
     }
 
     /// When consumers call 'POST' on '/posts' with valid JSON
     /// create and save the post
-    func create(req: Request) throws -> ResponseRepresentable {
+    func create(_ req: Request) throws -> ResponseRepresentable {
         let post = try req.post()
         try post.save()
         return post
@@ -20,27 +20,27 @@ final class PostController: ResourceRepresentable {
 
     /// When the consumer calls 'GET' on a specific resource, ie:
     /// '/posts/13rd88' we should show that specific post
-    func show(req: Request, post: Post) throws -> ResponseRepresentable {
+    func show(_ req: Request, post: Post) throws -> ResponseRepresentable {
         return post
     }
 
     /// When the consumer calls 'DELETE' on a specific resource, ie:
     /// 'posts/l2jd9' we should remove that resource from the database
-    func delete(req: Request, post: Post) throws -> ResponseRepresentable {
+    func delete(_ req: Request, post: Post) throws -> ResponseRepresentable {
         try post.delete()
         return Response(status: .ok)
     }
 
     /// When the consumer calls 'DELETE' on the entire table, ie:
     /// '/posts' we should remove the entire table
-    func clear(req: Request) throws -> ResponseRepresentable {
+    func clear(_ req: Request) throws -> ResponseRepresentable {
         try Post.makeQuery().delete()
         return Response(status: .ok)
     }
 
     /// When the user calls 'PATCH' on a specific resource, we should
     /// update that resource to the new values.
-    func update(req: Request, post: Post) throws -> ResponseRepresentable {
+    func update(_ req: Request, post: Post) throws -> ResponseRepresentable {
         // See `extension Post: Updateable`
         try post.update(for: req)
 
@@ -52,7 +52,7 @@ final class PostController: ResourceRepresentable {
     /// When a user calls 'PUT' on a specific resource, we should replace any
     /// values that do not exist in the request with null.
     /// This is equivalent to creating a new Post with the same ID.
-    func replace(req: Request, post: Post) throws -> ResponseRepresentable {
+    func replace(_ req: Request, post: Post) throws -> ResponseRepresentable {
         // First attempt to create a new Post from the supplied JSON.
         // If any required fields are missing, this request will be denied.
         let new = try req.post()

--- a/Sources/App/Controllers/PostController.swift
+++ b/Sources/App/Controllers/PostController.swift
@@ -12,8 +12,8 @@ final class PostController: ResourceRepresentable {
 
     /// When consumers call 'POST' on '/posts' with valid JSON
     /// create and save the post
-    func create(request: Request) throws -> ResponseRepresentable {
-        let post = try request.post()
+    func create(req: Request) throws -> ResponseRepresentable {
+        let post = try req.post()
         try post.save()
         return post
     }

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -46,7 +46,7 @@ class PostControllerTests: TestCase {
     func create() throws -> Int? {
         let req = Request.makeTest(method: .post)
         req.json = try JSON(node: ["content": initialMessage])
-        let res = try controller.create(req: req).makeResponse()
+        let res = try controller.create(req).makeResponse()
         
         let json = res.json
         XCTAssertNotNil(json)
@@ -59,7 +59,7 @@ class PostControllerTests: TestCase {
     func fetchOne(id: Int) throws {
         let req = Request.makeTest(method: .get)
         let post = try Post.find(id)!
-        let res = try controller.show(req: req, post: post).makeResponse()
+        let res = try controller.show(req, post: post).makeResponse()
 
         let json = res.json
         XCTAssertNotNil(json)
@@ -71,7 +71,7 @@ class PostControllerTests: TestCase {
 
     func fetchAll(expectCount count: Int) throws {
         let req = Request.makeTest(method: .get)
-        let res = try controller.index(req: req).makeResponse()
+        let res = try controller.index(req).makeResponse()
 
         let json = res.json
         XCTAssertNotNil(json?.array)
@@ -82,7 +82,7 @@ class PostControllerTests: TestCase {
         let req = Request.makeTest(method: .patch)
         req.json = try JSON(node: ["content": updatedMessage])
         let post = try Post.find(id)!
-        let res = try controller.update(req: req, post: post).makeResponse()
+        let res = try controller.update(req, post: post).makeResponse()
         
         let json = res.json
         XCTAssertNotNil(json)
@@ -96,7 +96,7 @@ class PostControllerTests: TestCase {
         let req = Request.makeTest(method: .put)
         req.json = try JSON(node: ["content": updatedMessage])
         let post = try Post.find(id)!
-        let res = try controller.replace(req: req, post: post).makeResponse()
+        let res = try controller.replace(req, post: post).makeResponse()
 
         let json = res.json
         XCTAssertNotNil(json)
@@ -110,12 +110,12 @@ class PostControllerTests: TestCase {
         let req = Request.makeTest(method: .delete)
         
         let post = try Post.find(id)!
-        _ = try controller.delete(req: req, post: post)
+        _ = try controller.delete(req, post: post)
     }
 
     func deleteAll() throws {
         let req = Request.makeTest(method: .delete)
-        _ = try controller.clear(req: req)
+        _ = try controller.clear(req)
     }
 }
 

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -46,7 +46,7 @@ class PostControllerTests: TestCase {
     func create() throws -> Int? {
         let req = Request.makeTest(method: .post)
         req.json = try JSON(node: ["content": initialMessage])
-        let res = try controller.create(request: req).makeResponse()
+        let res = try controller.create(req: req).makeResponse()
         
         let json = res.json
         XCTAssertNotNil(json)


### PR DESCRIPTION
All other methods have the Request parameter called `req` instead of `request`, thus I propose changing it from `request` to `req` for the `create` method as well.