### PR TITLE
Clear up create/store confusion

### DIFF
--- a/Sources/App/Controllers/PostController.swift
+++ b/Sources/App/Controllers/PostController.swift
@@ -11,7 +11,7 @@ final class PostController: ResourceRepresentable {
     }
 
     /// When consumers call 'POST' on '/posts' with valid JSON
-    /// create and save the post
+    /// construct and save the post
     func store(_ req: Request) throws -> ResponseRepresentable {
         let post = try req.post()
         try post.save()

--- a/Sources/App/Controllers/PostController.swift
+++ b/Sources/App/Controllers/PostController.swift
@@ -12,7 +12,7 @@ final class PostController: ResourceRepresentable {
 
     /// When consumers call 'POST' on '/posts' with valid JSON
     /// create and save the post
-    func create(_ req: Request) throws -> ResponseRepresentable {
+    func store(_ req: Request) throws -> ResponseRepresentable {
         let post = try req.post()
         try post.save()
         return post
@@ -73,7 +73,7 @@ final class PostController: ResourceRepresentable {
     func makeResource() -> Resource<Post> {
         return Resource(
             index: index,
-            store: create,
+            store: store,
             show: show,
             update: update,
             replace: replace,

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -22,13 +22,13 @@ class PostControllerTests: TestCase {
     let controller = PostController()
     
     func testPostRoutes() throws {        
-        let idOne = try create() ?? -1
+        let idOne = try storeNewPost() ?? -1
         try fetchOne(id: idOne)
         try fetchAll(expectCount: 1)
         try patch(id: idOne)
         try put(id: idOne)
 
-        let idTwo = try create() ?? -1
+        let idTwo = try storeNewPost() ?? -1
         try fetchAll(expectCount: 2)
 
         try deleteOne(id: idOne)
@@ -37,13 +37,13 @@ class PostControllerTests: TestCase {
         try deleteOne(id: idTwo)
         try fetchAll(expectCount: 0)
 
-        let newIds = try (1...5).map { _ in try create() ?? 1 }
+        let newIds = try (1...5).map { _ in try storeNewPost()? ?? 1 }
         try fetchAll(expectCount: newIds.count)
         try deleteAll()
         try fetchAll(expectCount: 0)
     }
 
-    func create() throws -> Int? {
+    func storeNewPost() throws -> Int? {
         let req = Request.makeTest(method: .post)
         req.json = try JSON(node: ["content": initialMessage])
         let res = try controller.store(req).makeResponse()

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -46,7 +46,7 @@ class PostControllerTests: TestCase {
     func create() throws -> Int? {
         let req = Request.makeTest(method: .post)
         req.json = try JSON(node: ["content": initialMessage])
-        let res = try controller.create(req).makeResponse()
+        let res = try controller.store(req).makeResponse()
         
         let json = res.json
         XCTAssertNotNil(json)

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -22,13 +22,21 @@ class PostControllerTests: TestCase {
     let controller = PostController()
     
     func testPostRoutes() throws {        
-        let idOne = try storeNewPost() ?? -1
+        guard let postOne = try storeNewPost(), let idOne = postOne.id?.int else {
+            XCTFail()
+            return
+        }
+
         try fetchOne(id: idOne)
         try fetchAll(expectCount: 1)
         try patch(id: idOne)
         try put(id: idOne)
 
-        let idTwo = try storeNewPost() ?? -1
+        guard let postTwo = try storeNewPost(), let idTwo = postTwo.id?.int else {
+            XCTFail()
+            return
+        }
+
         try fetchAll(expectCount: 2)
 
         try deleteOne(id: idOne)
@@ -37,23 +45,24 @@ class PostControllerTests: TestCase {
         try deleteOne(id: idTwo)
         try fetchAll(expectCount: 0)
 
-        let newIds = try (1...5).map { _ in try storeNewPost()? ?? 1 }
+        let newIds = try (1...5).map { _ in try storeNewPost()?.id?.int ?? 1 }
         try fetchAll(expectCount: newIds.count)
         try deleteAll()
         try fetchAll(expectCount: 0)
     }
 
-    func storeNewPost() throws -> Int? {
+    func storeNewPost() throws -> Post? {
         let req = Request.makeTest(method: .post)
         req.json = try JSON(node: ["content": initialMessage])
         let res = try controller.store(req).makeResponse()
         
         let json = res.json
         XCTAssertNotNil(json)
+        let newId: Int? = try json?.get("id")
+        XCTAssertNotNil(newId)
         XCTAssertNotNil(json?["content"])
-        XCTAssertNotNil(json?["id"])
         XCTAssertEqual(json?["content"], req.json?["content"])
-        return try json?.get("id")
+        return try Post.find(newId)
     }
 
     func fetchOne(id: Int) throws {

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -45,8 +45,10 @@ class PostControllerTests: TestCase {
         try deleteOne(id: idTwo)
         try fetchAll(expectCount: 0)
 
-        let newIds = try (1...5).map { _ in try storeNewPost()?.id?.int ?? 1 }
-        try fetchAll(expectCount: newIds.count)
+        for _ in 1...5 {
+            _ = try storeNewPost()
+        }
+        try fetchAll(expectCount: 5)
         try deleteAll()
         try fetchAll(expectCount: 0)
     }


### PR DESCRIPTION
While playing with my first Vapor project, I got quite confused about the responsibilities of the methods passed to a `Resource`-initializer's parameters, from looking at the example of the `PostController` and `PostControllerTests`.

My confusion was caused by passing a method called `create(_:)` as an argument to the parameter called `store:`, while there's also another optional parameter labeled `create:`, that's used for a different purpose. The `PostControllerTests`-cases then increased the confusion by using the controller's `create`-method, where what it does -privately- looks more like what I'd expect from a `store`-method.

With this PR I'm hoping to prevent some confusion for other Vapor-newbies about what the `create:` and `show:` parameters are for, mostly by removing the reliance on the word 'create' in the lines touched and using `store` where actually used in conjunction with the `store:` parameter.

Cheers!
EP

P.S. While trying to unconfuse myself I was tempted to change more about the `PostControllerTests`-file, but those changes would probably decrease the chance of you being willing to merge it. If you're curious I can add more commits to this PR, or create a new one.