### PR TITLE
PostControllerTests don't work correctly without droplet

### DIFF
--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -12,13 +12,8 @@ import Sockets
 class PostControllerTests: TestCase {
     let initialMessage = "I'm a post"
     let updatedMessage = "I have been updated \(Date())"
-
-    /// For these tests, we won't be spinning up a live
-    /// server, and instead we'll be passing our constructed
-    /// requests programmatically
-    /// this is usually an effective way to test your 
-    /// application in a convenient and safe manner
-    /// See RouteTests for an example of a live server test
+    
+    let drop = try! Droplet.testable()
     let controller = PostController()
     
     func testPostRoutes() throws {        


### PR DESCRIPTION
Without `let drop = try! Droplet.testable()` tests don't pass. See Xcode log without Droplet below: 
```console
Test Case '-[AppTests.PostControllerTests testPostRoutes]' started.
<unknown>:0: error: -[AppTests.PostControllerTests testPostRoutes] : failed: caught error: The operation couldn’t be completed. (Fluent.EntityError error 0.)
Test Case '-[AppTests.PostControllerTests testPostRoutes]' failed (0.522 seconds).
Test Suite 'PostControllerTests' failed at 2017-12-04 17:22:02.141.
	 Executed 1 test, with 1 failure (1 unexpected) in 0.522 (0.523) seconds
Test Suite 'AppTests.xctest' failed at 2017-12-04 17:22:02.142.
	 Executed 1 test, with 1 failure (1 unexpected) in 0.522 (0.525) seconds
Test Suite 'Selected tests' failed at 2017-12-04 17:22:02.143.
	 Executed 1 test, with 1 failure (1 unexpected) in 0.522 (0.526) seconds
Program ended with exit code: 1
```