### PR TITLE
App Model Helper

### DIFF
--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -2,7 +2,7 @@ import FluentSQLite
 import Vapor
 
 /// A single entry of a Todo list.
-final class Todo: SQLiteModel {
+final class Todo: AppModel {
     /// See `Model.idKey`
     static let idKey = \Todo.id
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,6 +1,9 @@
 import FluentSQLite
 import Vapor
 
+/// Helper protocol to make easier switch fluent drivers
+protocol AppModel: SQLiteModel {}
+
 /// Called before your application initializes.
 ///
 /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/structure/#configureswift)


### PR DESCRIPTION
# Motivation:

In Vapor 3, all models need to comform different protocol depending of the fluent driver. This PR allow the migration from one fluent driver to another without change your models, only need to change is the `AppModel` protocol