### PR TITLE
Fix comment typo

### DIFF
--- a/Sources/App/Controllers/TodoController.swift
+++ b/Sources/App/Controllers/TodoController.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-/// Controlers basic CRUD operations on `Todo`s.
+/// Controls basic CRUD operations on `Todo`s.
 final class TodoController {
     /// Returns a list of all `Todo`s.
     func index(_ req: Request) throws -> Future<[Todo]> {


### PR DESCRIPTION
Fixes a small typo in the generated `Hello, World` template

* Controlers -> Controls