### PR TITLE
Redirect root to "/hello"

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -2,6 +2,11 @@ import Vapor
 
 /// Register your application's routes here.
 public func routes(_ router: Router) throws {
+    // Redirect root to "/hello"
+    router.get("/") { req in
+        return req.redirect(to: "hello")
+    }
+
     // Basic "Hello, world!" example
     router.get("hello") { req in
         return "Hello, world!"


### PR DESCRIPTION
When starting [your first Vapor app](https://docs.vapor.codes/3.0/getting-started/hello-world/), it can be confusing if you accidentally visit the root instead of `/hello` and see the response `Not Found`.