### PR TITLE
Make the template ready for Cloud 2

### DIFF
--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,0 +1,29 @@
+# You can set the Swift version to what you need for your app. Versions can be found here: https://hub.docker.com/_/swift
+FROM swift:4.2 as builder
+
+# For local build, add `--build-arg environment=local`
+ARG env=""
+ENV ENVIRONMENT=$env
+
+RUN apt-get -qq update && apt-get -q -y install \
+  tzdata \
+  && rm -r /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so /build/lib
+RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
+
+# Production image
+FROM ubuntu:16.04
+RUN apt-get -qq update && apt-get install -y \
+  libicu55 libxml2 libbsd0 libcurl3 libatomic1 \
+  tzdata \
+  && rm -r /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /build/bin/Run .
+COPY --from=builder /build/lib/* /usr/lib/
+COPY --from=builder /app/Public ./Public
+# Uncommand the next line if you are using Leaf
+#COPY --from=builder /app/Resources ./Resources
+
+ENTRYPOINT ./Run serve --env $ENVIRONMENT --hostname 0.0.0.0 --port 80


### PR DESCRIPTION
This Dockerfile will give a Swift 4.2 template on Vapor Cloud 2.

It will copy the `Public` folder into the container, and have a commented line for `Resources` if people will add Leaf to the template.