### PR TITLE
Allow the Vapor app to be used as a library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "VaporApp",
+    products: [
+        .library(name: "VaporApp", targets: ["App"]),
+    ],
     dependencies: [
         // 💧 A server-side Swift web framework.
         .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),


### PR DESCRIPTION
This change allows you to import your newly generated Vapor app as a library/dependency in another project. 😜 While this may sound nutty at first, there are a number of potential use cases:

- Reuse some of your boilerplate Models and Controllers in another Vapor app.
- Import your Vapor backend to a Mac front-end app to use the same Models.
- Wrap a Vapor project so that it can be served in a different context (Kitura, Serverless, etc).

I don't think adding a library product has any negative impact on users who are using Vapor normally, and it's kind of nice to have it built in as an option! 🤷‍♂️