### PR TITLE
Simplify Dockerfile

### DIFF
--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -6,8 +6,7 @@ FROM swift:5.1.1 as builder
 ARG env
 
 RUN apt-get -qq update && apt-get install -y \
-  libssl-dev zlib1g-dev \
-  && rm -r /var/lib/apt/lists/*
+  libssl-dev zlib1g-dev
 WORKDIR /app
 COPY . .
 RUN swift build -c release && mkdir /build && mv `swift build -c release --show-bin-path` /build/bin

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get -qq update && apt-get install -y \
   && rm -r /var/lib/apt/lists/*
 WORKDIR /app
 COPY . .
-RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
-RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
+RUN swift build -c release && mkdir /build && mv `swift build -c release --show-bin-path` /build/bin
 
 # Production image
 FROM ubuntu:18.04
@@ -22,7 +21,7 @@ RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && rm -r /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/bin/Run .
-COPY --from=builder /build/lib/* /usr/lib/
+COPY --from=builder /usr/lib/swift/linux/*.so* /usr/lib/swift/linux/
 # Uncomment the next line if you need to load resources from the `Public` directory
 #COPY --from=builder /app/Public ./Public
 # Uncomment the next line if you are using Leaf


### PR DESCRIPTION
This PR include two changes in the intermediate image:

* Not duplicate swift libs to `/build/lib`, just copy them to final image directly.
* Not remove `/var/lib/apt/lists/*`, It's not necessary to make a slim intermediate image since it will be dropped after building process.

These two changes will decrease the building time, though just a little. 