### PR TITLE
Change MacOS platform version to v10_14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "app",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_14)
     ],
     products: [
         .executable(name: "Run", targets: ["Run"]),


### PR DESCRIPTION
The supported version from `vapor/vapor` is `v10_14` as in all other packages.