### PR TITLE
Fixes a typo in dockerfile

### DIFF
--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM vapor/swift:5.1 as build
+FROM vapor/swift:5.2 as build
 WORKDIR /build
 
 # Copy entire repo into container

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y \
 # Compile with optimizations
 RUN swift build \
 	--enable-test-discovery \
-	-c release
+	-c release \
 	-Xswiftc -g
 
 # ================================


### PR DESCRIPTION
The docker file for the beta templates misses a `\` that prevents the docker image from building. Also the new betas need Swift 5.2 to build.