### PR TITLE
Vapor Cloud Tidy Up

### DIFF
--- a/cloud.yml
+++ b/cloud.yml
@@ -1,3 +1,0 @@
-type: "vapor"
-swift_version: "4.1.0"
-run_parameters: "serve --port 8080 --hostname 0.0.0.0"


### PR DESCRIPTION
Remove the `cloud.yml` since Vapor Cloud is no longer a thing after Feb 29th