### PR TITLE
Due to https://bugs.swift.org/browse/SR-12354 , Swift 5.2 and Vapor 3…

### DIFF
--- a/Sources/App/Models/Todo.swift
+++ b/Sources/App/Models/Todo.swift
@@ -3,6 +3,7 @@ import Vapor
 
 /// A single entry of a Todo list.
 final class Todo: SQLiteModel {
+    typealias Database = SQLiteDatabase
     /// The unique identifier for this `Todo`.
     var id: Int?
 


### PR DESCRIPTION
Due to https://bugs.swift.org/browse/SR-12354 , Swift 5.2 and Vapor 3 cannot build new template projects, this commit adds a simple typealias so that Todo original class complies with SQLite Model