### PR TITLE
Improve Dockerfile for usage on Heroku and in general

### DIFF
--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -21,11 +21,13 @@ RUN swift build \
 # Run image
 # ================================
 FROM vapor/ubuntu:18.04
-WORKDIR /run
+WORKDIR /app
+
+ENV PORT 80
 
 # Copy build artifacts
-COPY --from=build /build/.build/release /run
+COPY --from=build /build/.build/release /app
 # Copy Swift runtime libraries
 COPY --from=build /usr/lib/swift/ /usr/lib/swift/
 
-ENTRYPOINT ["./Run", "serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "80"]
+CMD ./Run serve --env production --hostname 0.0.0.0 --port $PORT


### PR DESCRIPTION
This PR proposes three simple quality of life improvements to the template's Dockerfile:

1. It drops the application into `/app` instead of `/run` – which is actually already in use by the system [for transient run-time data](http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html). Not a place for application code to live in.
1. Keeps /bin/bash as the ENTRYPOINT of the image and uses a CMD line for starting the server. This helps debugging startup issues both locally – the image can now be started with `docker run -it someapp:sometag bash` to get a shell; and on Heroku with the container runtime, where `heroku run bash` can now be used to spin up a one-off dyno to look into the deployed files for example.
1. Makes the TCP port that the application listens on configurable via an environment variable (while keeping the unusual port 80 as the default). This change allows the image to be used on Heroku directly.

If it sticks, I think the other templates should get a similar treatment.